### PR TITLE
Stateless admin auth (HMAC token) + docs/env update

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Note: Backend uses an in-memory store for now to keep things simple for a first 
 ### Backend
 1) Copy env
 cp backend/.env.example backend/.env
-Edit ADMIN_EMAIL and ADMIN_PASSWORD. Add Payoneer credentials when available.
+Edit ADMIN_EMAIL and ADMIN_PASSWORD. Optionally set ADMIN_SECRET to sign stateless admin tokens (defaults to ADMIN_PASSWORD). Add Payoneer credentials when available.
 
 2) Install deps
 cd backend

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,5 +1,7 @@
 ADMIN_EMAIL=admin@example.com
 ADMIN_PASSWORD=change-me
+ADMIN_SECRET=change-me
+
 FRONTEND_ORIGIN=http://localhost:5173
 PAYONEER_MERCHANT_ID=
 PAYONEER_API_KEY=

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -1,23 +1,35 @@
 import os
-import secrets
+import hmac
+import hashlib
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 ADMIN_EMAIL = os.getenv("ADMIN_EMAIL", "admin@example.com")
 ADMIN_PASSWORD = os.getenv("ADMIN_PASSWORD", "change-me")
+ADMIN_SECRET = os.getenv("ADMIN_SECRET", ADMIN_PASSWORD)
 
-_token_store: set[str] = set()
 security = HTTPBearer()
+
+def _sign(payload: str) -> str:
+    return hmac.new(ADMIN_SECRET.encode(), payload.encode(), hashlib.sha256).hexdigest()
 
 def authenticate(email: str, password: str) -> str:
     if email == ADMIN_EMAIL and password == ADMIN_PASSWORD:
-        token = secrets.token_hex(32)
-        _token_store.add(token)
-        return token
+        payload = email
+        sig = _sign(payload)
+        return f"{payload}.{sig}"
     raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+
+def _verify(token: str) -> bool:
+    try:
+        payload, sig = token.rsplit(".", 1)
+    except ValueError:
+        return False
+    expected = _sign(payload)
+    return hmac.compare_digest(sig, expected) and payload == ADMIN_EMAIL
 
 def require_admin(credentials: HTTPAuthorizationCredentials = Depends(security)):
     token = credentials.credentials
-    if token in _token_store:
+    if _verify(token):
         return True
     raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")


### PR DESCRIPTION
# Stateless admin auth (HMAC token) + docs/env update

## Summary

This PR replaces the in-memory token store used for admin authentication with a stateless HMAC-signed token approach. This resolves deployment issues where the in-memory store was causing authentication failures in multi-instance environments (like Fly.io).

**Key Changes:**
- `backend/app/auth.py`: Replaced `_token_store` set with HMAC-SHA256 token signing/verification
- `backend/.env.example`: Added `ADMIN_SECRET` environment variable for token signing
- `README.md`: Updated setup documentation to mention the new `ADMIN_SECRET` variable

The new approach signs tokens with `{email}.{hmac_signature}` format and verifies them without server-side state.

## Review & Testing Checklist for Human

- [ ] **Test admin login flow**: Verify you can log into `/secret-admin/login` with admin@example.com / change-me
- [ ] **Test admin product management**: After login, verify you can create/edit/delete products from the admin panel  
- [ ] **Verify token security**: Confirm that manually crafted tokens are rejected (try modifying a valid token)
- [ ] **Test deployed environment**: Ensure the live deployment at https://app-yglafvrc.fly.dev works with the new auth
- [ ] **Check token persistence**: Verify admin sessions survive server restarts (unlike the old in-memory approach)

**Recommended Test Plan:**
1. Deploy this branch to staging/production
2. Clear browser localStorage and log in fresh as admin
3. Create a test product and verify it appears in the public catalog
4. Restart the backend service and verify the admin session still works

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    Auth["backend/app/auth.py"]:::major-edit
    Env["backend/.env.example"]:::minor-edit  
    README["README.md"]:::minor-edit
    Main["backend/app/main.py"]:::context
    Frontend["frontend/src/lib/api.ts"]:::context
    
    Auth --> Main
    Env --> Auth
    README --> Auth
    Frontend --> Main
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit  
        L3["Context/No Edit"]:::context
    end

classDef major-edit fill:#90EE90
classDef minor-edit fill:#87CEEB  
classDef context fill:#FFFFFF
```

### Notes

- This change was made to fix authentication issues in the deployed environment where the stateless nature of cloud deployments broke the in-memory token store
- The HMAC secret defaults to `ADMIN_PASSWORD` if `ADMIN_SECRET` is not set, maintaining backward compatibility
- Tokens do not have expiration built in - consider adding TTL if long-term security is a concern
- Successfully tested on the live deployment: admin login works and product creation is functional

**Session Info:**
- Requested by: Daniyal (@Daniyal-prodev)  
- Link to Devin run: https://app.devin.ai/sessions/e26f298e15ce4a33af3923fa04d36613